### PR TITLE
Add possibility to search by multiple fields

### DIFF
--- a/lib/exd/api.ex
+++ b/lib/exd/api.ex
@@ -28,6 +28,7 @@ defmodule Exd.Api do
   * `@exported`  - Defines attributes, which are exported with Api
   * `@hidden`    - Defines attributes, which are hidden on Api
   * `@required`  - Defines attributes, which are required on creation
+  * `@search`    - Defines fields for search 
   * `@optional`  - Defines attributes, which are optional
   * `@read_only` - Defines attributes, which can be readed, but can't be modified
   * `@model`     - Defined on use model
@@ -39,6 +40,7 @@ defmodule Exd.Api do
   * `__exd_api__(:exported)`  - Returns all exported attributes
   * `__exd_api__(:read_only)` - Returns only read_only attributes (defaults to `:id` `:inserted_at`, `:updated_at`)
   * `__exd_api__(:required)`  - Returns required for creation attributes
+  * `__exd_api__(:search)`    - Returns searchable fields 
   * `__exd_api__(:optional)`  - Returns optional for creation attributes
   * `__exd_api__(:changable)` - Returns changable for update attributes
 
@@ -125,6 +127,7 @@ defmodule Exd.Api do
       @exported @model.__schema__(:fields) -- (Module.get_attribute(__MODULE__, :hidden) || [])
       @read_only [:id, :inserted_at, :updated_at]
       @required (@exported -- @read_only) -- (Module.get_attribute(__MODULE__, :optional) || [])
+      @search Module.get_attribute(__MODULE__, :search) || :name in @model.__schema__(:fields) && [:name] || []
 
       api "options", :__options__
       @doc """
@@ -147,6 +150,7 @@ defmodule Exd.Api do
       def __exd_api__(:exported),  do: @exported
       def __exd_api__(:read_only), do: @read_only
       def __exd_api__(:required),  do: @required
+      def __exd_api__(:search),    do: @search
 
       @optional  (exported -- read_only) -- required
       @changable (exported -- read_only)

--- a/lib/exd/example.ex
+++ b/lib/exd/example.ex
@@ -36,6 +36,7 @@ if Mix.env in [:dev, :test] do
     @name "City"
     @tech_name "city"
     @optional [:country]
+    @search [:name, :country]
     use Exd.Api, model: City, repo: EctoIt.Repo
     crud
     def_service(:test_app)

--- a/mix.exs
+++ b/mix.exs
@@ -36,10 +36,10 @@ defmodule Exd.Mixfile do
      {:lager, "~> 2.1.1", override: true},
      {:exscript, "~> 0.0.1"},
      {:apix, "~> 0.1.0"},
-     {:ecto, "~> 0.15.0"},
-     {:ecto_migrate, "~> 0.6.0"},
+     {:ecto, "~> 0.16.0"},
+     {:ecto_migrate, "~> 0.6.1"},
      {:poison, "~> 1.4.0"},
-     {:ecdo, "~> 0.1.1"},
+     {:ecdo, "~> 0.1.2"},
 
      {:coverex, "~> 1.4.1", only: :test}, 
      {:meck, "~> 0.8.2", override: true, only: :test},

--- a/test/exd_hello_test.exs
+++ b/test/exd_hello_test.exs
@@ -80,6 +80,17 @@ defmodule ExdHelloTest do
     assert {:ok, %{"id" => wid}} = call("put", "weather", %{"id" => wid, "temp_lo" => 14, "temp_hi" => 25})
     assert {:ok, %{"temp_lo" => 14, "temp_hi" => 25}} = call("get", "weather", %{"id" => wid})
 
+    # search
+    assert {:ok, [%{"name" => "Novosibirsk"}, 
+                  %{"name" => "Omsk"}]} = call("get", "city", %{"search" => "%sk%"})
+    assert {:ok, [%{"name" => "Berlin"},
+                  %{"name" => "Novosibirsk"}, 
+                  %{"name" => "Moscow"},
+                  %{"name" => "Omsk"}]} = call("get", "city", %{"search" => "%i%"})
+    assert {:ok, [%{"name" => "Novosibirsk"}, 
+                  %{"name" => "Moscow"},
+                  %{"name" => "Omsk"}]} = call("get", "city", %{"search" => "%i%", "where" => "country == \"Russia\""})
+
     # delete
     assert {:ok, %{"id" => wid}} = call("delete", "weather", %{"id" => wid})
     assert {:ok, %{"id" => id}} = call("delete", "city", %{"id" => id})


### PR DESCRIPTION
You can add to API module `@search` for parametrize fields
By default it is `[:name]` if `:name` available, otherwise `[]` 

Relate to #17 
