### PR TITLE
Add nested API and application's API

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,20 @@ By using of `Exd.Api` you will be automatically get method options, which is pos
 iex> Apix.apply(Weather.Api, "options", %{})
 ```
 
+You can describe nested API via `apis` option in Exd.Api. If you want to use CLI or WEB you should have application's API. This is achieved by adding attribute `@app: true` to API module.
+
+For example:
+
+```elixir
+defmodule Example.Api do
+  @moduledoc "Example application"
+  @name "Example"
+  @tech_name "exd"
+  @app true
+  use Exd.Api, apis: [City.Api, Weather.Api]
+end
+```
+
 CLI
 ---
 

--- a/lib/exd/escript/main.ex
+++ b/lib/exd/escript/main.ex
@@ -1,18 +1,21 @@
 defmodule Exd.Escript.Main do
+  
   @parse_opts [switches: [formatter: :string, input: :string, remoter: :string]]
+
   def main(args) do
     {opts, args, _} = OptionParser.parse(args, @parse_opts)
     remoter = Exd.Escript.Remoter.get( opts[:remoter] || "dist" ) || fail("remoter: #{opts[:remoter]} not supported")
-    script = script()
-    local_apps = remoter.applications(script)
-    main(args, opts, script, remoter, local_apps)
+    local_apps = remoter.applications(script())
+    main(args, opts, remoter, local_apps)
   end
 
-  def main([], _opts, script, _remoter, local_apps) do
-    apps = local_apps |> Stream.map(&elem(&1, 0)) |> Enum.join(", ")
+
+  defp main([], _opts, _remoter, local_apps) do
+    apps = local_apps |> Stream.map(&elem(&1, 0)) |> Enum.join(", ") 
     example_app = map_key(local_apps, "app")
     example_api = local_apps[example_app] |> map_key("api")
     link = "#{ example_app }/#{ example_api }"
+    script = script()
     IO.puts """
 usage: #{script} <command> <link> <data...> <opts...>
 
@@ -58,59 +61,45 @@ available opts:
 """
   end
 
-  def main([command],opts, script, remoter, local_apps) do
+  defp main([command], opts, remoter, local_apps) do
     IO.puts "Error: 'exd #{command}' command must have options"
-    main([], opts, script, remoter, local_apps)
+    main([], opts, remoter, local_apps)
   end
 
-  def main([command, link | payload], opts, script, remoter, local_apps) do
+  defp main([command, link | payload], opts, remoter, local_apps) do
     [app | link_rest] = String.split(link, "/")
-    apis = local_apps[app] || fail("application: #{app} not found")
-    on_app(command, opts, app, link_rest, payload, apis, script, remoter)
+    app_api = local_apps[app] || fail("application: #{app} not found")
+    on_app(command, opts, link_rest, payload, app_api, remoter)
   end
 
-  #defp main(node, _model, api, "list", []) do
-  #  select(node, api, %{})
-  #end
-
-  #defp main(node, _, api, "subscribe", ["where" | subscription_info]) do
-  #  sub_info = Enum.reduce(subscription_info, "", fn(info, acc) -> info <> " " <> acc <> " " end) |> String.rstrip
-  #  rpc(node, api.subscribe(sub_info, [adapter: Ecto.Subscribe.Adapter.Remote, receiver: node()])) |> IO.inspect
-  #  :timer.sleep(:infinity)
-  #end
-
-  defp on_app("options", _opts, app, [], _, apis, script, _remoter) do
+  defp on_app("options", _opts, [], _, app, _remoter) do
     IO.puts """
-link: #{app}
+link: #{app[:name]}
 
 available apis:
-#{ Enum.map(apis, &print_api(&1, script)) }
+#{ Enum.map(app, &print_api(&1, app[:name]))}
 """
   end
 
-  defp on_app(command, opts, app, [api], payload, apis, script, remoter) do
-    api_map = apis[api] || fail("application: #{app}: api #{api} not found")
-    IO.puts("link: #{app}/#{api}")
-    on_command(command, opts, api_map, payload, script, remoter)
+  defp on_app(command, opts, [api], payload, app, remoter) do
+    api_map = app[api] || fail("application: #{app[:name]}: api #{api} not found")
+    IO.puts("link: #{app[:name]}/#{api}")
+    on_command(command, opts, api_map, payload, remoter)
   end
 
-  defp on_command(command, opts, api, payload, _script, remoter) do
+  defp on_command(command, opts, api, payload, remoter) do
     payload_map = payload(payload, opts[:input] || "native")
     result = remoter.remote(api, command, payload_map)
     result_to_string(command, opts[:formatter] || "native", result) |> IO.puts
   end
 
-  defp print_api({_, %{app: app, name: name, desc_name: desc_name, description: doc}}, script) do
+  defp print_api({_, %{name: name, desc_name: desc_name, description: doc}}, app) do
     "  #{name} - #{desc_name}: #{doc}    example: #{script} option #{app}/#{name}"
   end
+  defp print_api(_, _), do: []
 
-  defp result_to_string(_command, "native", result) do
-    "#{inspect result}"
-  end
-
-  defp result_to_string(_command, "json", result) do
-    Poison.encode!(result) |> :jsx.prettify
-  end
+  defp result_to_string(_command, "native", result), do: "#{inspect result}"
+  defp result_to_string(_command, "json", result), do: Poison.encode!(result) |> :jsx.prettify
 
   defp payload(payload, "native") do
     splited = Enum.map(payload, &String.split(&1, ":", parts: 2))

--- a/lib/exd/example.ex
+++ b/lib/exd/example.ex
@@ -42,4 +42,11 @@ if Mix.env in [:dev, :test] do
     def_service(:test_app)
   end
 
+  defmodule Example.Api do
+    @moduledoc "Example application"
+    @name "Example"
+    @tech_name "exd"
+    @app true
+    use Exd.Api, apis: [City.Api, Weather.Api]
+  end
 end

--- a/lib/exd/model/dummy.ex
+++ b/lib/exd/model/dummy.ex
@@ -1,0 +1,5 @@
+import Exd.Model
+model Exd.Model.Dummy do
+  schema "exd_dummy_model" do
+  end
+end


### PR DESCRIPTION
These changes add functionality for future routing and export api support:
- Nested API via `apis` option for Exd.API. 
- Application's API (root) via `@api true`. Exd will build application tree starting from this module not from OTP application as in the past

See `example.ex` or more samples.

Relate to #30 
