### PR TITLE
use extern form of where (not an intern), as it has bug, which leads to

### DIFF
--- a/lib/exd/api.ex
+++ b/lib/exd/api.ex
@@ -28,7 +28,7 @@ defmodule Exd.Api do
   * `@exported`  - Defines attributes, which are exported with Api
   * `@hidden`    - Defines attributes, which are hidden on Api
   * `@required`  - Defines attributes, which are required on creation
-  * `@search`    - Defines fields for search 
+  * `@search`    - Defines fields for search
   * `@optional`  - Defines attributes, which are optional
   * `@read_only` - Defines attributes, which can be readed, but can't be modified
   * `@model`     - Defined on use model
@@ -41,7 +41,7 @@ defmodule Exd.Api do
   * `__exd_api__(:exported)`  - Returns all exported attributes
   * `__exd_api__(:read_only)` - Returns only read_only attributes (defaults to `:id` `:inserted_at`, `:updated_at`)
   * `__exd_api__(:required)`  - Returns required for creation attributes
-  * `__exd_api__(:search)`    - Returns searchable fields 
+  * `__exd_api__(:search)`    - Returns searchable fields
   * `__exd_api__(:optional)`  - Returns optional for creation attributes
   * `__exd_api__(:changable)` - Returns changable for update attributes
   * `__exd_api__(:tech_name)` - Returns value of the tech_name attribute
@@ -117,8 +117,8 @@ defmodule Exd.Api do
   end
 
   defp instruction_apis(apis) do
-    Stream.map(apis, 
-               fn api -> 
+    Stream.map(apis,
+               fn api ->
                  introspection = Apix.apply(api, "options", %{})
                  {introspection[:name], introspection}
                end) |> Enum.into(%{})
@@ -157,8 +157,8 @@ defmodule Exd.Api do
   @doc false
   defmacro __before_compile__(env) do
     module = env.module
-    [required, exported, read_only, app] = for attr <- [:required, :exported, :read_only, :app], 
-                                             do: Module.get_attribute(module, attr) 
+    [required, exported, read_only, app] = for attr <- [:required, :exported, :read_only, :app],
+                                             do: Module.get_attribute(module, attr)
     quote bind_quoted: [exported: exported, read_only: read_only, required: required, app: app] do
       def __exd_api__(:model),     do: @model
       def __exd_api__(:repo),      do: @repo

--- a/lib/exd/api/crud.ex
+++ b/lib/exd/api/crud.ex
@@ -78,12 +78,17 @@ defmodule Exd.Api.Crud do
   end
 
   defp get_one(api, %{"id" => id} = params) do
-    params = put_in(params["where"], [{:==, "id", id}])
+    # FIXME: get back to form of [{:==, :id, id}]
+    # Once it doesn't generate it to a query with literals ids.
+    # Problem is, that if we doesn't replace it with parameters (as we do it in id == "xyz")
+    # the resulting query is "WHERE (a0.`id` = 1)" instead of WHERE (a0.`id` = ?)"
+    # it results in much entries in prepared statements cache and in performance degradation.
+    params = put_in(params["where"], ~s(id == "#{id}"))
     data = model(api) |> Ecdo.query(params) |> repo(api).one |> save
     unless_error(data, api, data)
   end
   defp get_one(api, %{"name" => name} = params) do
-    params = put_in(params["where"], [{:==, "name", name}])
+    params = put_in(params["where"], ~s(name == "#{name}"))
     data = model(api) |> Ecdo.query(params) |> repo(api).one |> save
     unless_error(data, api, data)
   end


### PR DESCRIPTION
performance degradation

problem is, that if we doesn't replace it with parameters (as we do it in id == "xyz")
the resulting query is "WHERE (a0.`id` = 1)" instead of WHERE (a0.`id` = ?)"
it results in much entries in prepared statements cache and in performance degradation.

the query in form of string parameters (Note id too as string: ~s(id == "#{id}")
are interpolated right and not used as literals in query. Later for integer
should be fixed too.

this fix should be seen, only quick fix temporar fix, until it is properly
fixed in ecdo
