### PR TITLE
Add metrics for API

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,37 @@ Expose ecto to erlang application
 
 As the ecto interface is based heavily on macros, and not directly invokable in erlang, there should exists reach erlang API to allow to handle and manipulate Ecto model from erlang application. [WiP]
 
+Metrics
+-------
+
+EXD collect some metrics via exometer_core.
+If you want to report metrics to reporters you should subscribe to each API like this:
+
+    Exd.Metrics.subscribe(City.Api)
+
+It will collect the following metrics:
+
+* [:api, resource, :requests, method, :per_sec, :ok] - spiral.
+Successful requests per second.
+
+* [:api, resource, :requests, method, :per_sec, :error] - spiral.
+Unsuccessful requests per second.
+
+* [:api, resource, :requests, method, :per_sec, :db_not_available] - spiral.
+Unsuccessful requests with reason db_not_available per second
+
+* [:api, resource, :request, method, :handle_time] - histogram.
+`mean` and `max` handling time for one requests with 1 minute time span. 
+
+`resource`,  `method` and `type`(:ok, error, :db_not_available) will be transformed to tags if you use exometer_influxdb reporter.
+For example:
+
+    [:api, :private_user, :requests, :post, :ok, :per_sec]
+
+becoming
+
+    api_requests_per_sec,resource=private_user,method=post,type=ok
+
 Model-driven development
 ------------------------
 

--- a/lib/exd/api.ex
+++ b/lib/exd/api.ex
@@ -149,7 +149,8 @@ defmodule Exd.Api do
       Method: `options`.
       Introspection of #{String.downcase(@name)} API.
       """
-      def __options__(_args), do: Exd.Api.introspection(__MODULE__)
+      def __options__(_args), do: 
+        Exd.Metrics.request(__MODULE__, :options, fn -> Exd.Api.introspection(__MODULE__) end)
       defdelegate [__schema__(target), __schema__(target, id)], to: unquote(model)
     end
   end

--- a/lib/exd/api/crud.ex
+++ b/lib/exd/api/crud.ex
@@ -276,7 +276,8 @@ defmodule Exd.Api.Crud do
 
         #{ Exd.Api.Crud.description(@model, @exported, @read_only, @required, :post) }
         """
-        def __post__(args), do: Exd.Api.Crud.post(__MODULE__, args)
+        def __post__(args), do:
+          Exd.Metrics.request(__MODULE__, :post, fn -> Exd.Api.Crud.post(__MODULE__, args) end)
       end
 
       if :put in actions do
@@ -289,7 +290,8 @@ defmodule Exd.Api.Crud do
 
         #{ Exd.Api.Crud.description(@model, @exported, @read_only, @required, :put) }
         """
-        def __put__(args), do: Exd.Api.Crud.put(__MODULE__, args)
+        def __put__(args), do:
+          Exd.Metrics.request(__MODULE__, :put, fn -> Exd.Api.Crud.put(__MODULE__, args) end)
       end
 
       if :get in actions do
@@ -302,7 +304,8 @@ defmodule Exd.Api.Crud do
 
         #{ Exd.Api.Crud.description(@model, @exported, @read_only, @required, :get) }
         """
-        def __get__(args), do: Exd.Api.Crud.get(__MODULE__, args)
+        def __get__(args), do:
+          Exd.Metrics.request(__MODULE__, :get, fn -> Exd.Api.Crud.get(__MODULE__, args) end)
       end
 
       if :delete in actions do
@@ -315,7 +318,8 @@ defmodule Exd.Api.Crud do
 
         #{ Exd.Api.Crud.description(@model, @exported, @read_only, @required, :delete) }
         """
-        def __delete__(args), do: Exd.Api.Crud.delete(__MODULE__, args)
+        def __delete__(args), do:
+          Exd.Metrics.request(__MODULE__, :delete, fn -> Exd.Api.Crud.delete(__MODULE__, args) end)
       end
     end
   end

--- a/lib/exd/metrics.ex
+++ b/lib/exd/metrics.ex
@@ -1,0 +1,54 @@
+defmodule Exd.Metrics do
+  @default_time 1000
+
+  def subscribe(api) do
+    for {reporter, _} <- :exometer_report.list_reporters do
+      tags = [resource: {:from_name, 2},
+              method: {:from_name, 4}]
+      tags_with_type = tags ++ [type: {:from_name, 5}]
+      for crud <- api.__apix__(:methods) do
+        for result <- [:ok, :error, :db_not_available_error] do
+          name = name(api, crud, [result, :per_sec])
+          :exometer_report.subscribe(reporter, name, :one, @default_time, tags_with_type, true)
+        end
+        name = name(api, crud, :handle_time)
+        :exometer_report.subscribe(reporter, name, :max, @default_time, tags, true)
+        :exometer_report.subscribe(reporter, name, :mean, @default_time, tags, true)
+      end
+    end
+  end
+
+  def request(api, method, fun) do
+    {time, value} = :timer.tc(fun)
+    case value do
+      %{errors: %{database: "not available"}} -> db_error_request(api, method)
+      %{errors: _} -> error_request(api, method)
+      _ -> ok_request(api, method)
+    end
+    handle_time(api, method, time / 1000)
+    value
+  end
+
+  defp ok_request(api, method) do
+    :exometer.update_or_create(name(api, method, [:ok, :per_sec]), 1, :spiral, [{:time_span, 1000}])
+  end
+
+  defp error_request(api, method) do
+    :exometer.update_or_create(name(api, method, [:error, :per_sec]), 1, :spiral, [{:time_span, 1000}])
+  end
+
+  defp db_error_request(api, method) do
+    :exometer.update_or_create(name(api, method, [:db_not_available_error, :per_sec]), 1, :spiral, [{:time_span, 1000}])
+  end
+
+  defp handle_time(api, method, time), do:
+    :exometer.update_or_create(name(api, method, :handle_time), time, :histogram, [{:truncate, false}])
+
+  defp name(api, method, :handle_time), do:
+    [:api, "#{api.__exd_api__(:tech_name)}" |> String.to_atom, :request, "#{method}" |> String.to_atom, :handle_time]
+    |> List.flatten
+
+  defp name(api, method, name), do:
+    [:api, "#{api.__exd_api__(:tech_name)}" |> String.to_atom, :requests, "#{method}" |> String.to_atom, name]
+    |> List.flatten
+end

--- a/mix.exs
+++ b/mix.exs
@@ -13,7 +13,7 @@ defmodule Exd.Mixfile do
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: [:logger, :ecto, :ecto_migrate, :ecdo, :apix],
+    [applications: [:logger, :ecto, :ecto_migrate, :ecdo, :apix, :exometer_core],
      mod: {Exd, []}]
   end
 
@@ -32,7 +32,9 @@ defmodule Exd.Mixfile do
      {:ecto_it,  "~> 0.2.0", optional: true},
      {:jsx,      "~> 2.6.2"},
      {:hello, github: "travelping/hello", optional: true},
+     {:exometer_core, github: "Feuerlabs/exometer_core", override: true},
      {:hackney, "~> 1.3.1", override: true},
+     {:edown, github: "uwiger/edown", override: true},
 
      {:lager, "~> 2.1.1", override: true},
      {:exscript, "~> 0.0.1"},


### PR DESCRIPTION
it will collect the following metrics:
- [:api, resource, :requests, method, :per_sec, :ok] - spiral.
  Successful requests per second.
- [:api, resource, :requests, method, :per_sec, :error] - spiral.
  Unsuccessful requests per second.
- [:api, resource, :requests, method, :per_sec, :db_not_available] - spiral.
  Unsuccessful requests with reason db_not_available per second
- [:api, resource, :requests, method, :handle_time] - histogram.
  Handling time for one request

`resource`,  `method` and `type`(:ok, error, :db_not_available) will be transformed to tags if you use exometer_influxdb reporter.
For example:

```
[:api, :private_user, :requests, :post, :ok, :per_sec]
```

becoming

```
api_requests_per_sec,resource=private_user,method=post,type=ok
```

If you want to report metrics to reporters you should subscribe to each API like this:

```
Exd.Metrics.subscribe(City.Api)
```
