### PR TITLE
Added credo dependency for Elixir code analysis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install avahi-daemon libavahi-compat-libdnssd-dev
   - epmd -daemon
+  - mix do deps.get, credo
 language: elixir
 elixir:
     - 1.0.5
 otp_release:
     - 17.5
     - 18.0
-script: "MIX_ENV=test mix do deps.get, deps.compile, credo, test --cover"
+script: "MIX_ENV=test mix do deps.get, deps.compile, test --cover"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,10 @@ before_install:
   - sudo apt-get update -qq
   - sudo apt-get install avahi-daemon libavahi-compat-libdnssd-dev
   - epmd -daemon
-  - mix do deps.get, credo
 language: elixir
 elixir:
     - 1.0.5
 otp_release:
     - 17.5
     - 18.0
-script: "MIX_ENV=test mix do deps.get, deps.compile, test --cover"
+script: "MIX_ENV=test mix do deps.get, deps.compile, test --cover, credo"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ elixir:
 otp_release:
     - 17.5
     - 18.0
-script: "MIX_ENV=test mix do deps.get, deps.compile, test --cover"
+script: "MIX_ENV=test mix do deps.get, deps.compile, credo, test --cover"

--- a/mix.exs
+++ b/mix.exs
@@ -49,6 +49,7 @@ defmodule Exd.Mixfile do
 
      {:earmark, "~> 0.1", only: :dev},
      {:ex_doc, "~> 0.7", only: :dev},
-     {:ecto_taggable, github: "xerions/ecto_taggable"}]
+     {:ecto_taggable, github: "xerions/ecto_taggable"},
+     {:credo, "~> 0.2", only: [:dev, :test]}]
   end
 end


### PR DESCRIPTION
Credo is a static code analysis tool for the Elixir language with a focus on teaching and code consistency. More documentation can be found at https://github.com/rrrene/credo
