### PR TITLE
Metrics Rework

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,36 +146,25 @@ As the ecto interface is based heavily on macros, and not directly invokable in 
 Metrics
 -------
 
-EXD collect some metrics via exometer_core.
-If you want to report metrics to reporters you should subscribe to each API like this:
+EXD collects some metrics via exometer_core. If you want to report those metrics you have to initialize metrics to each API:
 
-    Exd.Metrics.subscribe(City.Api)
+    Exd.Metrics.init_metrics(City.Api)
 
 It will collect the following metrics:
 
-* [:api, resource, :requests, method, :per_sec, :ok] - spiral.
-Successful requests per second.
+    * request counter
+    * request handle times
+    * object counter
 
-* [:api, resource, :requests, method, :per_sec, :error] - spiral.
-Unsuccessful requests per second.
+The request metrics are broken down by the method which was used (put, post, delete, update)
+and by the status of the request (success, error, db_not_available). Further a request counter
+and handle time metric is initialized at start for all API calls combined.
 
-* [:api, resource, :requests, method, :per_sec, :db_not_available] - spiral.
-Unsuccessful requests with reason db_not_available per second
+The handle times metrics are internally generated using histograms. These histograms have a time span of 60s.
 
-* [:api, resource, :request, method, :handle_time] - histogram.
-`mean` and `max` handling time for one requests with 1 minute time span. 
+The exometer IDs can be viewed in the Exd.Metrics module or just execute `:exometer_report.list_metrics([:exd])`
+_after_ you initialized your API metrics.
 
-* [:api, resource, :objects] - function
-Number of objects of `resource` in database.
-
-`resource`,  `method` and `type`(:ok, error, :db_not_available) will be transformed to tags if you use exometer_influxdb reporter.
-For example:
-
-    [:api, :private_user, :requests, :post, :ok, :per_sec]
-
-becoming
-
-    api_requests_per_sec,resource=private_user,method=post,type=ok
 
 Model-driven development
 ------------------------

--- a/config/config.exs
+++ b/config/config.exs
@@ -23,5 +23,8 @@ use Mix.Config
 #
 #     import_config "#{Mix.env}.exs"
 
+config :exd, :metrics,
+  enabled: [:object, :request]
+
 config :ecto_it, EctoIt.Repo,
   adapter: Ecto.Adapters.Postgres

--- a/lib/exd.ex
+++ b/lib/exd.ex
@@ -14,6 +14,7 @@ defmodule Exd do
     # See http://elixir-lang.org/docs/stable/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: Exd.Supervisor]
+    Exd.Metrics.init_metrics()
     Supervisor.start_link(children, opts)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -14,6 +14,7 @@ defmodule Exd.Mixfile do
   # Type `mix help compile.app` for more information
   def application do
     [applications: [:logger, :ecto, :ecto_migrate, :ecdo, :apix, :exometer_core],
+     env: [metrics: [enabled: [:object, :request]]],
      mod: {Exd, []}]
   end
 

--- a/test/exd_dist_test.exs
+++ b/test/exd_dist_test.exs
@@ -14,8 +14,26 @@ defmodule ExdDistTest do
   test_with_mock "remoter", :net_adm, [:unstick, :passthrough], 
     [localhost: fn() -> Atom.to_string(node()) |> String.split("@") |> List.last |> String.to_char_list end] do
      remoter = Exd.Escript.Remoter.get("dist")
+
+     # This will initialize the metrics for the city api on top of the native metrics.
+     Exd.Metrics.init_metrics(City.Api)
+
      %{"id": val} = remoter.remote("exd/city", "post", %{"name" => "testcity"})
      assert 1 = val
+
+     # Check the metrics for the first single request.
+     # There is one initial request included in the request counters,
+     # therefore we get '2' requests where the method is 'total'.
+     assert {:ok,[{:value, 2}, _]} = :exometer.get_value([:exd,:request,:total,:city,:total,:counter])
+     assert {:ok,[{:value, 2}, _]} = :exometer.get_value([:exd,:request,:total,:city,:success,:counter])
+     assert {:ok,[{:value, 1}, _]} = :exometer.get_value([:exd,:request,:post,:city,:success,:counter])
+     assert {:ok,[{:value, total}, _]} = :exometer.get_value([:exd,:request,:total,:total,:total,:counter])
+     assert {:ok,[{:value, total_success}, _]} = :exometer.get_value([:exd,:request,:total,:total,:success,:counter])
+     assert true = total > 0
+     assert true = total_success > 0
+
+     # Since a city is inserted there is a city object in the database
+     assert {:ok,[value: 1]} = :exometer.get_value([:exd,:object,:city,:counter])
 
      tag = remoter.remote("exd/city/tag", "post", %{"name" => "testcity", "tag" => "tag1", "tag_value" => "tag_for_city"})
      assert %{id: 1} == tag


### PR DESCRIPTION
- remove subscription mechanisms in favor of
  application specific subscriptions
- requests now have a counter and handle time for metrics;
  the 'request per second' metric is removed
- add metrics for all requests (combining all API calls)
- update README
