### PR TITLE
update to elixir-1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,9 @@ before_install:
   - epmd -daemon
 language: elixir
 elixir:
-    - 1.0.5
+    - 1.2.6
+    - 1.3.2
 otp_release:
-    - 17.5
-    - 18.0
+    - 18.3
+    - 19.0
 script: "MIX_ENV=test mix do deps.get, deps.compile, test --cover"

--- a/lib/exd/api.ex
+++ b/lib/exd/api.ex
@@ -151,7 +151,8 @@ defmodule Exd.Api do
       """
       def __options__(_args), do: 
         Exd.Metrics.request(__MODULE__, :options, fn -> Exd.Api.introspection(__MODULE__) end)
-      defdelegate [__schema__(target), __schema__(target, id)], to: unquote(model)
+      defdelegate __schema__(target), to: unquote(model)
+      defdelegate __schema__(target, id), to: unquote(model)
     end
   end
 

--- a/lib/exd/api/tag.ex
+++ b/lib/exd/api/tag.ex
@@ -38,7 +38,7 @@ defmodule Exd.Api.Tag do
   end
 
   def delete(repo, params) do
-    {tagname, tagvalue, model, params} = get_data_for_tag(params)
+    {_tagname, tagvalue, model, params} = get_data_for_tag(params)
     case params do
       [] -> Ecto.Taggable.Api.drop_tag(repo, model, tagvalue, tagvalue)
       _ ->  Ecto.Taggable.Api.drop_tag(repo, model |> repo.get_by(params), tagvalue, tagvalue)

--- a/mix.exs
+++ b/mix.exs
@@ -35,9 +35,10 @@ defmodule Exd.Mixfile do
      {:hello, github: "travelping/hello", optional: true},
      {:exometer_core, github: "Feuerlabs/exometer_core", branch: "master", override: true},
      {:hackney, "~> 1.3.1", override: true},
+     {:msgpack, "~> 0.6.0", override: true},
      {:edown, github: "uwiger/edown", branch: "master", override: true},
 
-     {:lager, "~> 2.1.1", override: true},
+     {:lager, "~> 3.2.1", override: true},
      {:exscript, "~> 0.0.1"},
      {:apix, "~> 0.1.0"},
      {:ecto_migrate, "~> 0.6.2"},


### PR DESCRIPTION
Warning fixes which are occured in elixir-1.3.

Ecto is not updated. Updated dependencies are only need for otp-19 and elixir-1.3
