### PR TITLE
convert :null to nil args value before method executing

### DIFF
--- a/lib/exd/plugin/hello.ex
+++ b/lib/exd/plugin/hello.ex
@@ -17,6 +17,17 @@ if Code.ensure_loaded?(:hello) do
     Implementation of `handle_request/4` for a service.
     """
     def handle_request(api, method, args, state) do
+      args = if method == "post" or method == "put" do
+               Enum.map(args, fn({k, v}) ->
+                 v = if v == :null do
+                       nil
+                     else v end
+                 {k, v}
+               end)
+               |> Enum.into(%{})
+             else
+               args
+             end
       result = if method in api.__apix__(:methods) do
                  {:ok, nil2null(api.__apix__(:apply, method, args))}
                else

--- a/test/exd_hello_test.exs
+++ b/test/exd_hello_test.exs
@@ -35,11 +35,13 @@ defmodule ExdHelloTest do
     assert {:ok, %{"id" => _}} = call("post", "city", %{"country" => "UK", "name" => "London"})
     assert {:ok, %{"id" => wid}} = call("post", "weather", %{"name" => "Weather", "city_id" => id, "temp_lo" => 15})
     assert {:ok, %{"id" => _}} = call("post", "weather", %{"name" => "Weather1", "city_id" => nid, "temp_lo" => -30})
+    assert {:ok, %{"id" => id}} = call("post", "city", ["name": "City", "country": :null])
 
     # get
     assert {:ok, %{"country" => :null, "name" => "Berlin"}} = call("get", "exd/city", %{"name" => "Berlin"})
     assert {:ok, %{"country" => :null, "weather" => [%{"temp_hi" => :null, "temp_lo" => 15}]}}
            = call("get", "exd/city", %{"name" => "Berlin", "load" => ["weather"]})
+    assert {:ok, %{"country" => :null, "name" => "City"}} = call("get", "exd/city", %{"name" => "City"})
 
     # count
     assert {:ok, [%{"count" => 1}]} = call("get", "exd/city", %{"where" => "country == \"UK\"", "count" => "id"})
@@ -95,7 +97,8 @@ defmodule ExdHelloTest do
     assert {:ok, [%{"name" => "Berlin"},
                   %{"name" => "Novosibirsk"},
                   %{"name" => "Moscow"},
-                  %{"name" => "Omsk"}]} = call("get", "exd/city", %{"search" => "%i%"})
+                  %{"name" => "Omsk"},
+                  %{"name" => "City"}]} = call("get", "exd/city", %{"search" => "%i%"})
     assert {:ok, [%{"name" => "Novosibirsk"},
                   %{"name" => "Moscow"},
                   %{"name" => "Omsk"}]} = call("get", "exd/city", %{"search" => "%i%", "where" => "country == \"Russia\""})


### PR DESCRIPTION
After execution of a method we convert nil values to null to represent
null values in json in a correct way. We also need to convert null
values to nil before execution of a method to represent correctly
these values in database.